### PR TITLE
Fix build, remove workaround for ngscopeclient/scopehal-apps/issues/624

### DIFF
--- a/Formula/ngscopeclient.rb
+++ b/Formula/ngscopeclient.rb
@@ -11,14 +11,14 @@ class Ngscopeclient < Formula
   depends_on "catch2"
   depends_on "glfw"
   depends_on "glslang"
+  depends_on "hidapi"
   depends_on "libomp"
+  depends_on "libpng"
+  depends_on "libsigc++"
   depends_on "pkg-config"
   depends_on "spirv-tools"
   depends_on "vulkan-loader"
   depends_on "yaml-cpp"
-  depends_on "libsigc++"
-  depends_on "hidapi"
-  depends_on "libpng"
 
   on_macos do
     depends_on "molten-vk"

--- a/Formula/ngscopeclient.rb
+++ b/Formula/ngscopeclient.rb
@@ -34,11 +34,6 @@ class Ngscopeclient < Formula
       'if(binDir.find("/usr") != 0)',
       "if(binDir.find(\"#{HOMEBREW_PREFIX}\") != 0)"
 
-    # Patch search paths for Homebrew prefix #624
-    inreplace "lib/scopehal/scopehal.cpp",
-      'g_searchPaths.push_back(binRootDir + "/share/ngscopeclient");',
-      'g_searchPaths.push_back(binRootDir + "/../share/ngscopeclient");'
-
     system "cmake", "-S", ".", "-B", "build", "-DBUILD_DOCS=NO",
       "-DCMAKE_INSTALL_RPATH=#{rpath};#{vulkan_loader_lib}",
       *std_cmake_args


### PR DESCRIPTION
The formula contains an outdated workaround for https://github.com/ngscopeclient/scopehal-apps/issues/624. Because the patch no longer applies, the formula does not build.

Nit: Sort dependencies alphabetically to follow Homebrew style.